### PR TITLE
Update base.py to fix ValueError when importing

### DIFF
--- a/PyMart/base.py
+++ b/PyMart/base.py
@@ -204,7 +204,7 @@ class DataBase(Base):
     """
     name: str = ""
     display_name: str = ""
-    _datasets: pd.DataFrame = pd.DataFrame(columns=["name", "display_name"])
+    _datasets: pd.DataFrame = field(default_factory=pd.DataFrame(columns=["name", "display_name"]))
 
     def _get_datasets(self):
         """
@@ -338,7 +338,7 @@ class Filter:
     type: str
     operator: str
     sub_options: bool
-    options: pd.DataFrame = pd.DataFrame()
+    options: pd.DataFrame = field(default_factory=pd.DataFrame())
 
     def explain_filter(self, print_options=True):
         """
@@ -377,7 +377,7 @@ class DataSet(Base):
     _config_xml: object = None
     _attributes: List[Attribute] = field(default_factory=list)
     _filters: List[Filter] = field(default_factory=list)
-    _homology: pd.DataFrame = pd.DataFrame()
+    _homology: pd.DataFrame = field(default_factory=pd.DataFrame())
 
     @property
     def config_xml(self):


### PR DESCRIPTION
Updated base.py to remove errors regarding selecting DataFrames as defaults in dataclass parameters.

Aiming to fix #1 - ValueError: mutable default <class 'pandas.core.frame.DataFrame'> for field _datasets is not allowed: use default_factory